### PR TITLE
call setup function of wrapped service

### DIFF
--- a/packages/server/src/index.js
+++ b/packages/server/src/index.js
@@ -82,6 +82,11 @@ class RealtimeClass extends AdapterService {
       this._listenOptions();
     }
 
+    // Make sure that the wrapped service is setup correctly
+    if (typeof this.remoteService.setup === 'function') {
+      this.remoteService.setup(app, path);
+    }
+
     debug('  Done.');
     return true;
   }

--- a/packages/server/test/server.test.js
+++ b/packages/server/test/server.test.js
@@ -94,6 +94,27 @@ describe('RealtimeServerWrapper', () => {
         expect(err.name).to.equal('XXX', `Adapter class unexpectedly throws '${err.name}' ${err.message}`);
       }
     })
+
+    it('should setup wrapped service', () => {
+      app = feathers();
+
+      let setupCalled = false;
+      let passedApp;
+      let passedPath;
+
+      app.use(path, {
+        setup(app, path) {
+          setupCalled = true;
+          passedApp = app;
+          passedPath = path
+        }
+      });
+      realtimeWrapper(app, path, {});
+
+      expect(setupCalled).to.equal(true, 'setup was called');
+      expect(typeof passedApp).to.equals('object', 'app argument was passed');
+      expect(passedPath).to.equal(path, 'path argument was passed');
+    });
   });
 
   describe('real-life tests', () => {


### PR DESCRIPTION
### Summary

In my feathersjs application I use
```
...
exports.SomeService= class SomeService extends Service {
  setup(app, path) {
    this.app = app;
  }
}
...
```
to register the `app` object onto the service. 
I need this so I can internally call other service methods (i. e. `this.app.service('someOtherService').find()`)

Normally feathersjs automatically calls all `setup` functions, but because the service is wrapped by the `RealtimeServer` it does not happen.

I've added the code to call the `setup` function of the wrapped service and also added a test for it.